### PR TITLE
The controller execution was very old. 

### DIFF
--- a/com_lendr/site/lendr.php
+++ b/com_lendr/site/lendr.php
@@ -20,12 +20,12 @@ LendrHelpersStyle::load();
 //application
 $app = JFactory::getApplication();
  
-// Require specific controller if requested
-$controller = $app->input->get('controller','default');
 
-// Create the controller
-$classname  = 'LendrControllers'.ucwords($controller);
-$controller = new $classname();
+// It will look for controller.php file in component root directory
+$controller = JControllerLegacy::getInstance('Cobalt');
+
+// Now you can task like this task=controller.action
+$controller->execute(JFactory::getApplication()->input->get('task'));
  
 // Perform the Request task
 $controller->execute();


### PR DESCRIPTION
Derived even from Joomla 1.5. That way only trigger tasks like `controller=controlername&task=taskname` but now natively in Joomla it works like this `task=contolername.taskname`
